### PR TITLE
Custom grammar support

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -64,6 +64,9 @@ type GenerateRequest struct {
 	// Format specifies the format to return a response in.
 	Format string `json:"format"`
 
+	// Grammar to use for a custom format
+	Grammar string `json:"grammar,omitempty"`
+
 	// KeepAlive controls how long the model will stay loaded in memory following
 	// this request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
@@ -82,6 +85,7 @@ type ChatRequest struct {
 	Messages  []Message `json:"messages"`
 	Stream    *bool     `json:"stream,omitempty"`
 	Format    string    `json:"format"`
+	Grammar  string    `json:"grammar,omitempty"`
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
 
 	Options map[string]interface{} `json:"options"`

--- a/llm/server.go
+++ b/llm/server.go
@@ -525,6 +525,7 @@ type completion struct {
 type CompletionRequest struct {
 	Prompt  string
 	Format  string
+	Grammar string
 	Images  []ImageData
 	Options api.Options
 }
@@ -577,6 +578,9 @@ func (s *LlamaServer) Completion(ctx context.Context, req CompletionRequest, fn 
 		if !strings.Contains(strings.ToLower(req.Prompt), "json") {
 			slog.Warn("Prompt does not specify that the LLM should response in JSON, but JSON format is expected. For best results specify that JSON is expected in the system prompt.")
 		}
+	} else if req.Format == "custom" {
+		request["grammar"] = req.Grammar
+		slog.Warn("Using custom grammar")
 	}
 
 	retryDelay := 100 * time.Microsecond

--- a/server/routes.go
+++ b/server/routes.go
@@ -176,8 +176,8 @@ func GenerateHandler(c *gin.Context) {
 	case req.Model == "":
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
-	case len(req.Format) > 0 && req.Format != "json":
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "format must be json"})
+	case len(req.Format) > 0 && (req.Format != "json" && req.Format != "custom"):
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "format must be json or custom"})
 		return
 	case req.Raw && (req.Template != "" || req.System != "" || len(req.Context) > 0):
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "raw mode does not support template, system, or context"})
@@ -356,6 +356,7 @@ func GenerateHandler(c *gin.Context) {
 		req := llm.CompletionRequest{
 			Prompt:  prompt,
 			Format:  req.Format,
+			Grammar: req.Grammar,
 			Images:  images,
 			Options: opts,
 		}
@@ -1254,8 +1255,8 @@ func ChatHandler(c *gin.Context) {
 	case req.Model == "":
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
-	case len(req.Format) > 0 && req.Format != "json":
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "format must be json"})
+	case len(req.Format) > 0 && (req.Format != "json" && req.Format != "custom"):
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "format must be json or custom"})
 		return
 	}
 
@@ -1379,6 +1380,7 @@ func ChatHandler(c *gin.Context) {
 		if err := loaded.llama.Completion(c.Request.Context(), llm.CompletionRequest{
 			Prompt:  prompt,
 			Format:  req.Format,
+			Grammar: req.Grammar,
 			Images:  images,
 			Options: opts,
 		}, fn); err != nil {


### PR DESCRIPTION
Added the ability to specify custom grammars by setting format=custom and grammar=<gbnf>. See the [documentation in the llama.cpp repo](https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md)

Example of usage:

```javascript
await fetch("http://localhost:11434/api/generate", {
    "body": JSON.stringify({
        "model":"llama3:latest",
        "prompt":"just want to see how you're doing\n",
        // you can also just set format = "json" and leave out grammar
        // you should make sure your prompt helps the model respond in the way you want
        // so if you want json say you want json in the prompt
        // for custom grammars give an example in the system prompt
        "format": "custom",
        "grammar": `
        // only return markdown lists
        root ::= item+
        
        # Excludes various line break characters
        item ::= \"- \" [^\\r\\x0b\\x0c\\x85\\u2028\\u2029]+ \"\\n\"`, 
        "stream": false,

        "system":""
    }),
    "headers": {
        "Content-Type": "application/json",
    },
    "method": "POST",
    "mode": "cors",
}).then(r => r.text())
```